### PR TITLE
Kargo Bid Adapter: Use currency from Bid Response

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -87,7 +87,7 @@ export const spec = {
         creativeId: adUnit.id,
         dealId: adUnit.targetingCustom,
         netRevenue: true,
-        currency: bidRequest.currency,
+        currency: (adUnit.currency && adUnit.currency) || bidRequest.currency,
         meta: meta
       });
     }

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -493,6 +493,15 @@ describe('kargo adapter tests', function () {
           adm: '<div id="2"></div>',
           width: 300,
           height: 250
+        },
+        4: {
+          id: 'bar',
+          cpm: 2.5,
+          adm: '<div id="4"></div>',
+          width: 300,
+          height: 250,
+          metadata: {},
+          currency: 'EUR'
         }
       }}, {
         currency: 'USD',
@@ -508,6 +517,11 @@ describe('kargo adapter tests', function () {
           }
         }, {
           bidId: 3,
+          params: {
+            placementId: 'bar'
+          }
+        }, {
+          bidId: 4,
           params: {
             placementId: 'bar'
           }
@@ -551,6 +565,17 @@ describe('kargo adapter tests', function () {
         dealId: undefined,
         netRevenue: true,
         currency: 'USD',
+        meta: undefined
+      }, {
+        requestId: '4',
+        cpm: 2.5,
+        width: 300,
+        height: 250,
+        ad: '<div id="4"></div>',
+        creativeId: 'bar',
+        dealId: undefined,
+        netRevenue: true,
+        currency: 'EUR',
         meta: undefined
       }];
       expect(resp).to.deep.equal(expectation);


### PR DESCRIPTION
## Type of change
- [ ] Bugfix
- [x] Feature
- [ ] New bidder adapter
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Does this change affect user-facing APIs or examples documented on http://prebid.org?
- [ ] Other

## Description of change
Updates the Kargo Bid Adapter to use the `response.body.[].currency` field from the Kargo Bid Response, otherwise defaulting to using the Bid Request currency like before.

## Other information
- Implements [KRAK-3527](https://kargo1.atlassian.net/browse/KRAK-3527)
- The currency field was added to the Kargo Bid Response at [KRAK-3526](https://kargo1.atlassian.net/browse/KRAK-3526)