### PR TITLE
Kargo: Adding Social Canvas support

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -61,6 +61,13 @@ export const spec = {
       },
       prebidRawBidRequests: validBidRequests
     }, spec._getAllMetadata(bidderRequest, tdid));
+
+    // Pull Social Canvas segments and embed URL
+    if (validBidRequests.length > 0 && validBidRequests[0].params.socialCanvas) {
+      transformedParams.socialCanvasSegments = validBidRequests[0].params.socialCanvas.segments;
+      transformedParams.socialEmbedURL = validBidRequests[0].params.socialCanvas.embedURL;
+    }
+
     const encodedParams = encodeURIComponent(JSON.stringify(transformedParams));
     return Object.assign({}, bidderRequest, {
       method: 'GET',


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
Adds support for Kargo's Social Canvas product

Be sure to test the integration with your adserver using the [Hello World](/integrationExamples/gpt/hello_world.html) sample page.

- contact email of the adapter’s maintainer: jeremy@kargo.com