### PR TITLE
NoTicket: Re-adding raw CRB data

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -78,11 +78,13 @@ function buildRequests(validBidRequests, bidderRequest) {
   const firstBidRequest = validBidRequests[0];
   const tdidAdapter = deepAccess(firstBidRequest, REQUEST_KEYS.TDID_ADAPTER);
 
+  const metadata = getAllMetadata(bidderRequest);
+
   const krakenParams = Object.assign({}, {
     pbv: PREBID_VERSION,
     aid: firstBidRequest.auctionId,
     sid: _getSessionId(),
-    url: getAllMetadata(bidderRequest).pageURL,
+    url: metadata.pageURL,
     timeout: bidderRequest.timeout,
     ts: new Date().getTime(),
     device: {
@@ -92,7 +94,9 @@ function buildRequests(validBidRequests, bidderRequest) {
       ]
     },
     imp: impressions,
-    user: getUserIds(tdidAdapter, bidderRequest.uspConsent, bidderRequest.gdprConsent, firstBidRequest.userIdAsEids)
+    user: getUserIds(tdidAdapter, bidderRequest.uspConsent, bidderRequest.gdprConsent, firstBidRequest.userIdAsEids),
+    rawCRB: metadata.rawCRB,
+    rawCRBLocalStorage: metadata.rawCRBLocalStorage,
   });
 
   const reqCount = getRequestCount()


### PR DESCRIPTION
Hey Neil - to make the transition easier with the unknowns around CMA APAC at the moment, I've re-added the raw cookie and local storage data so we can continue sending that to the server.

The plan right now...
1. I've updated our Akamai CDN for Ad Tag to pass back a cookie "krg_seg=1" when the user is in APAC
2. The Ad Tag is [going to work on a ticket](https://kargo1.atlassian.net/browse/KAT-4847) to only retrieve CMA segments when that cookie is set.
3. As cookies die out, the segments will be removed from them everywhere except APAC. Because of this, the raw data we're sending in with this pull request will end up being pretty tiny, and we can look to remove it completely in the future.