### PR TITLE
KRKPD-987: floors should reference Floors Module

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -13,7 +13,6 @@ const BIDDER = Object.freeze({
   REQUEST_ENDPOINT: '/api/v1/prebid',
   TIMEOUT_ENDPOINT: '/api/v1/event/timeout',
   GVLID: 972,
-  //  NATIVE?? Referenced below as well as https://docs.prebid.org/dev-docs/bidders/kargo.html
   SUPPORTED_MEDIA_TYPES: [BANNER, VIDEO],
 });
 

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -452,32 +452,6 @@ function sendTimeoutData(auctionId, auctionTimeout) {
   } catch (e) {}
 }
 
-function getBidFloors(bid, mediaType) {
-  let floorInfo;
-  try {
-    floorInfo = bid.getFloor({
-      currency: 'USD',
-      mediaType,
-      size: '*'
-    });
-  } catch (e) {
-    logError('Kargo: getFloor threw an error: ', e);
-  }
-  return typeof floorInfo === 'object' && floorInfo.currency === 'USD' && !isNaN(parseInt(floorInfo.floor)) ? floorInfo.floor : undefined;
-}
-
-function getHighestFloor(bannerFloor, videoFloor, nativeFloor) {
-  const validFloors = [bannerFloor, videoFloor, nativeFloor].filter(floor => !isNaN(floor));
-
-  if (validFloors.length === 0) {
-    return null;
-  }
-
-  const highestFloor = Math.max(...validFloors);
-
-  return highestFloor;
-}
-
 function getImpression(bid) {
   const imp = {
     id: bid.bidId,
@@ -507,33 +481,31 @@ function getImpression(bid) {
 
   if (bid.mediaTypes) {
     const { banner, video, native } = bid.mediaTypes;
-    let bannerFloor, videoFloor, nativeFloor;
-    const hasGetFloor = typeof bid.getFloor === 'function';
 
     if (banner) {
       imp.banner = banner;
-      if (hasGetFloor) {
-        bannerFloor = getBidFloors(bid, 'banner');
-      }
     }
 
     if (video) {
       imp.video = video;
-      if (hasGetFloor) {
-        videoFloor = getBidFloors(bid, 'video');
-      }
     }
 
     if (native) {
       imp.native = native;
-      if (hasGetFloor) {
-        nativeFloor = getBidFloors(bid, 'native');
-      }
     }
 
-    const highestFloor = getHighestFloor(bannerFloor, videoFloor, nativeFloor);
-    if (highestFloor) {
-      imp.floor = highestFloor;
+    if (typeof bid.getFloor === 'function') {
+      let floorInfo;
+      try {
+        floorInfo = bid.getFloor({
+          currency: 'USD',
+          mediaType: '*',
+          size: '*'
+        });
+      } catch (e) {
+        logError('Kargo: getFloor threw an error: ', e);
+      }
+      imp.floor = typeof floorInfo === 'object' && floorInfo.currency === 'USD' && !isNaN(parseInt(floorInfo.floor)) ? floorInfo.floor : undefined;
     }
   }
 

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -1,4 +1,4 @@
-import { _each, isEmpty, buildUrl, deepAccess, pick, triggerPixel } from '../src/utils.js';
+import { _each, isEmpty, buildUrl, deepAccess, pick, triggerPixel, logError } from '../src/utils.js';
 import { config } from '../src/config.js';
 import { registerBidder } from '../src/adapters/bidderFactory.js';
 import { getStorageManager } from '../src/storageManager.js';

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -459,10 +459,6 @@ function getImpression(bid) {
     code: bid.adUnitCode
   };
 
-  if (bid.floorData != null && bid.floorData.floorMin > 0) {
-    imp.floor = bid.floorData.floorMin;
-  }
-
   if (bid.bidRequestsCount > 0) {
     imp.bidRequestCount = bid.bidRequestsCount;
   }
@@ -493,6 +489,20 @@ function getImpression(bid) {
 
     if (bid.mediaTypes.native != null) {
       imp.native = bid.mediaTypes.native;
+    }
+
+    if (typeof bid.getFloor === 'function') {
+      let floorInfo;
+      try {
+        floorInfo = bid.getFloor({
+          currency: 'USD',
+          mediaType: bid.mediaTypes.video ? 'video' : 'banner',
+          size: '*'
+        });
+      } catch (e) {
+        logError('Kargo: getFloor threw an error: ', e);
+      }
+      imp.floor = typeof floorInfo === 'object' && floorInfo.currency === 'USD' && !isNaN(parseInt(floorInfo.floor)) ? floorInfo.floor : undefined;
     }
   }
 

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -492,7 +492,7 @@ describe('kargo adapter tests', function () {
             fpd: {
               gpid: '/22558409563,18834096/dfy_mobile_adhesion'
             },
-            floor: 1
+            floor: 2
           },
           {
             code: '303',
@@ -505,7 +505,7 @@ describe('kargo adapter tests', function () {
             fpd: {
               gpid: '/22558409563,18834096/dfy_mobile_adhesion'
             },
-            floor: 1
+            floor: 3
           }
         ],
         socan: {
@@ -608,7 +608,13 @@ describe('kargo adapter tests', function () {
       }
 
       clonedBids.forEach(bid => {
-        bid.getFloor = () => ({ currency: 'USD', floor: 1 });
+        if (bid.mediaTypes.banner) {
+          bid.getFloor = () => ({ currency: 'USD', floor: 1 });
+        } else if (bid.mediaTypes.video) {
+          bid.getFloor = () => ({ currency: 'USD', floor: 2 });
+        } else if (bid.mediaTypes.native) {
+          bid.getFloor = () => ({ currency: 'USD', floor: 3 });
+        }
       });
 
       var request = spec.buildRequests(clonedBids, payload);

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -491,7 +491,8 @@ describe('kargo adapter tests', function () {
             },
             fpd: {
               gpid: '/22558409563,18834096/dfy_mobile_adhesion'
-            }
+            },
+            floor: 1
           },
           {
             code: '303',
@@ -503,7 +504,8 @@ describe('kargo adapter tests', function () {
             },
             fpd: {
               gpid: '/22558409563,18834096/dfy_mobile_adhesion'
-            }
+            },
+            floor: 1
           }
         ],
         socan: {
@@ -604,6 +606,10 @@ describe('kargo adapter tests', function () {
       if (gdpr) {
         payload['gdprConsent'] = gdpr
       }
+
+      clonedBids.forEach(bid => {
+        bid.getFloor = () => ({ currency: 'USD', floor: 1 });
+      });
 
       var request = spec.buildRequests(clonedBids, payload);
       var krakenParams = request.data;


### PR DESCRIPTION
## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Bugfix

## Description of change
- Previous code was referencing implementation specific to [analytics adapters](https://docs.prebid.org/dev-docs/modules/floors.html#bid-adapter-interface:~:text=Example%20getFloor()%20scenarios-,Analytics%20Adapter%20Interface,-Prebid%20Server%20Interface). This changes code to use [bid adapter implementation](https://docs.prebid.org/dev-docs/modules/floors.html#bid-adapter-interface:~:text=3%20%2D%20Schema%202-,Bid%20Adapter%20Interface,-getFloor()%20Response). 
- `getFloor({mediaType: '*',size: '*'` utilizes Prebid's smart rule selection to choose most appropriate pub-specific price rule based on adunit configured mediatype and size

![Screenshot 2024-03-07 at 3 06 16 PM](https://github.com/KargoGlobal/Prebid.js/assets/12804307/cd176713-1957-4da8-8651-056c08903ddf)


Open Questions:
- [ ] consider native (remove code? or add as supported mediatype?)