### PR TITLE
KRKPD-1031: Adds full ortb2 and ortb2Imp to request

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -95,13 +95,16 @@ function buildRequests(validBidRequests, bidderRequest) {
       ]
     },
     imp: impressions,
-    user: getUserIds(tdidAdapter, bidderRequest.uspConsent, bidderRequest.gdprConsent, firstBidRequest.userIdAsEids, bidderRequest.gppConsent),
+    user: getUserIds(tdidAdapter, bidderRequest.uspConsent, bidderRequest.gdprConsent, firstBidRequest.userIdAsEids, bidderRequest.gppConsent)
   });
 
-  if (firstBidRequest.ortb2 != null) {
-    krakenParams.site = {
-      cat: firstBidRequest.ortb2.site.cat
+  // Add full ortb2 object as backup
+  if (firstBidRequest.ortb2) {
+    const siteCat = firstBidRequest.ortb2.site?.cat;
+    if (siteCat != null) {
+      krakenParams.site = { cat: siteCat };
     }
+    krakenParams.ext = { ortb2: firstBidRequest.ortb2 };
   }
 
   // Add schain
@@ -476,6 +479,11 @@ function getImpression(bid) {
     imp.fpd = {
       gpid: gpid
     }
+  }
+
+  // Add full ortb2Imp object as backup
+  if (bid.ortb2Imp) {
+    imp.ext = { ortb2Imp: bid.ortb2Imp };
   }
 
   if (bid.mediaTypes) {

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -479,6 +479,21 @@ describe('kargo adapter tests', function () {
             floor: 1,
             fpd: {
               gpid: '/22558409563,18834096/dfy_mobile_adhesion'
+            },
+            ext: {
+              ortb2Imp: {
+                ext: {
+                  tid: '10101',
+                  data: {
+                    adServer: {
+                      name: 'gam',
+                      adslot: '/22558409563,18834096/dfy_mobile_adhesion'
+                    },
+                    pbadslot: '/22558409563,18834096/dfy_mobile_adhesion'
+                  },
+                  gpid: '/22558409563,18834096/dfy_mobile_adhesion'
+                }
+              }
             }
           },
           {
@@ -492,7 +507,21 @@ describe('kargo adapter tests', function () {
             fpd: {
               gpid: '/22558409563,18834096/dfy_mobile_adhesion'
             },
-            floor: 2
+            floor: 2,
+            ext: {
+              ortb2Imp: {
+                ext: {
+                  tid: '20202',
+                  data: {
+                    adServer: {
+                      name: 'gam',
+                      adslot: '/22558409563,18834096/dfy_mobile_adhesion'
+                    },
+                    pbadslot: '/22558409563,18834096/dfy_mobile_adhesion'
+                  }
+                }
+              }
+            }
           },
           {
             code: '303',
@@ -505,7 +534,21 @@ describe('kargo adapter tests', function () {
             fpd: {
               gpid: '/22558409563,18834096/dfy_mobile_adhesion'
             },
-            floor: 3
+            floor: 3,
+            ext: {
+              ortb2Imp: {
+                ext: {
+                  tid: '30303',
+                  data: {
+                    adServer: {
+                      name: 'gam',
+                      adslot: '/22558409563,18834096/dfy_mobile_adhesion'
+                    }
+                  },
+                  gpid: '/22558409563,18834096/dfy_mobile_adhesion'
+                }
+              }
+            }
           }
         ],
         socan: {
@@ -555,6 +598,56 @@ describe('kargo adapter tests', function () {
               ]
             }
           ]
+        },
+        ext: {
+          ortb2: {
+            device: {
+              sua: {
+                platform: {
+                  brand: 'macOS',
+                  version: ['12', '6', '0']
+                },
+                browsers: [
+                  {
+                    brand: 'Chromium',
+                    version: ['106', '0', '5249', '119']
+                  },
+                  {
+                    brand: 'Google Chrome',
+                    version: ['106', '0', '5249', '119']
+                  },
+                  {
+                    brand: 'Not;A=Brand',
+                    version: ['99', '0', '0', '0']
+                  }
+                ],
+                mobile: 1,
+                model: 'model',
+                source: 1,
+              }
+            },
+            site: {
+              id: '1234',
+              name: 'SiteName',
+              cat: ['IAB1', 'IAB2', 'IAB3']
+            },
+            user: {
+              data: [
+                {
+                  name: 'prebid.org',
+                  ext: {
+                    segtax: 600,
+                    segclass: 'v1',
+                  },
+                  segment: [
+                    {
+                      id: '133'
+                    },
+                  ]
+                },
+              ]
+            }
+          }
         }
       };
 


### PR DESCRIPTION
## Type of change
- [x] Feature
- [x] Other

## Description of change
Ingests/passes full ortb2 and ortb2Imp objects in request.

ortb2 is passed at `root.ext.ortb2`
ortb2Imp is passed at `imp.ext.ortb2Imp`

![Screenshot 2024-03-21 at 11 41 04 AM](https://github.com/KargoGlobal/Prebid.js/assets/12804307/d3158fc3-4396-4885-ab39-a6ef21236486)

bcat/badv example
![Screenshot 2024-03-21 at 1 02 04 PM](https://github.com/KargoGlobal/Prebid.js/assets/12804307/2b4b033f-957c-4091-bdfb-c6a5cebe4551)

