### PR TITLE
KRKPD-1247: sends refererInfo to Kraken

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -95,16 +95,13 @@ function buildRequests(validBidRequests, bidderRequest) {
       ]
     },
     imp: impressions,
-    user: getUserIds(tdidAdapter, bidderRequest.uspConsent, bidderRequest.gdprConsent, firstBidRequest.userIdAsEids, bidderRequest.gppConsent)
+    user: getUserIds(tdidAdapter, bidderRequest.uspConsent, bidderRequest.gdprConsent, firstBidRequest.userIdAsEids, bidderRequest.gppConsent),
+    ext: getExtensions(firstBidRequest.ortb2, bidderRequest?.refererInfo)
   });
 
-  // Add full ortb2 object as backup
-  if (firstBidRequest.ortb2) {
-    const siteCat = firstBidRequest.ortb2.site?.cat;
-    if (siteCat != null) {
-      krakenParams.site = { cat: siteCat };
-    }
-    krakenParams.ext = { ortb2: firstBidRequest.ortb2 };
+  // Add site.cat if it exists
+  if (firstBidRequest.ortb2?.site?.cat != null) {
+    krakenParams.site = { cat: firstBidRequest.ortb2.site.cat };
   }
 
   // Add schain
@@ -184,6 +181,10 @@ function buildRequests(validBidRequests, bidderRequest) {
   }
   if (!isEmpty(page)) {
     krakenParams.page = page;
+  }
+
+  if (krakenParams.ext && Object.keys(krakenParams.ext).length === 0) {
+    delete krakenParams.ext;
   }
 
   return Object.assign({}, bidderRequest, {
@@ -298,6 +299,13 @@ function onTimeout(timeoutData) {
   timeoutData.forEach((bid) => {
     sendTimeoutData(bid.auctionId, bid.timeout);
   });
+}
+
+function getExtensions(ortb2, refererInfo) {
+  const ext = {};
+  if (ortb2) ext.ortb2 = ortb2;
+  if (refererInfo) ext.refererInfo = refererInfo;
+  return Object.keys(ext).length > 0 ? ext : undefined;
 }
 
 function _generateRandomUUID() {

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -305,7 +305,7 @@ function getExtensions(ortb2, refererInfo) {
   const ext = {};
   if (ortb2) ext.ortb2 = ortb2;
   if (refererInfo) ext.refererInfo = refererInfo;
-  return Object.keys(ext).length > 0 ? ext : undefined;
+  return ext;
 }
 
 function _generateRandomUUID() {

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -300,7 +300,7 @@ describe('kargo adapter tests', function() {
           domain,
           isAmp: false,
           location: topUrl,
-          numIframs: 0,
+          numIframes: 0,
           page: topUrl,
           reachedTop: true,
           ref: referer,
@@ -428,12 +428,12 @@ describe('kargo adapter tests', function() {
           }
         }
       }]);
-      expect(payload.ext).to.deep.equal({ ortb2: {
+      expect(payload.ext.ortb2).to.deep.equal({
         user: { key: 'value' }
-      }});
+      });
 
       payload = getPayloadFromTestBids(testBids);
-      expect(payload.ext).to.be.undefined;
+      expect(payload.ext.ortb2).to.be.undefined;
 
       payload = getPayloadFromTestBids([{
         ...minimumBidParams,
@@ -450,9 +450,33 @@ describe('kargo adapter tests', function() {
           }
         }
       }]);
-      expect(payload.ext).to.deep.equal({ortb2: {
+      expect(payload.ext.ortb2).to.deep.equal({
         user: { key: 'value' }
-      }});
+      }
+      );
+    });
+
+    it('copies the refererInfo object from bidderRequest if present', function() {
+      let payload;
+      payload = getPayloadFromTestBids(testBids);
+      expect(payload.ext.refererInfo).to.deep.equal({
+        canonicalUrl: 'https://random.com/this/is/a/url',
+        domain: 'random.com',
+        isAmp: false,
+        location: 'https://random.com/this/is/a/url',
+        numIframes: 0,
+        page: 'https://random.com/this/is/a/url',
+        reachedTop: true,
+        ref: 'https://random.com/',
+        stack: [
+          'https://random.com/this/is/a/url'
+        ],
+        topmostLocation: 'https://random.com/this/is/a/url'
+      });
+
+      delete bidderRequest.refererInfo
+      payload = getPayloadFromTestBids(testBids);
+      expect(payload.ext).to.be.undefined;
     });
 
     it('pulls the site category from the first bids ortb2 object', function() {

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -476,6 +476,7 @@ describe('kargo adapter tests', function() {
 
       delete bidderRequest.refererInfo
       payload = getPayloadFromTestBids(testBids);
+      console.log(JSON.stringify(payload))
       expect(payload.ext).to.be.undefined;
     });
 

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -476,7 +476,6 @@ describe('kargo adapter tests', function() {
 
       delete bidderRequest.refererInfo
       payload = getPayloadFromTestBids(testBids);
-      console.log(JSON.stringify(payload))
       expect(payload.ext).to.be.undefined;
     });
 


### PR DESCRIPTION
https://kargo1.atlassian.net/browse/KRKPD-1247

## Type of change
<!-- Remove items that don't apply and/or select an item by changing [ ] to [x] -->
- [x] Feature

## Description of change
- Sends refererInfo to bidder under krakenParams.ext
- Maintains ortb2 functionality; slight refactor on how that data is applied to ext since now we have multiple objects coming through there
![Screenshot 2024-06-05 at 11 41 58 AM](https://github.com/KargoGlobal/Prebid.js/assets/12804307/bf90b281-0cd5-43e0-9326-0a9d2be993d9)
![Screenshot 2024-06-05 at 11 41 36 AM](https://github.com/KargoGlobal/Prebid.js/assets/12804307/932a22e4-d990-436e-b04a-5b5206bb93fe)

