### PR TITLE
KRKPD-1319: removes idx and loop to create 5 syncs

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -48,7 +48,7 @@ const SUA_ATTRIBUTES = [
 
 const CERBERUS = Object.freeze({
   KEY: 'krg_crb',
-  SYNC_URL: 'https://crb.kargo.com/api/v1/initsyncrnd/{UUID}?seed={SEED}&idx={INDEX}&gdpr={GDPR}&gdpr_consent={GDPR_CONSENT}&us_privacy={US_PRIVACY}&gpp={GPP_STRING}&gpp_sid={GPP_SID}',
+  SYNC_URL: 'https://crb.kargo.com/api/v1/initsyncrnd/{UUID}?seed={SEED}&gdpr={GDPR}&gdpr_consent={GDPR_CONSENT}&us_privacy={US_PRIVACY}&gpp={GPP_STRING}&gpp_sid={GPP_SID}',
   SYNC_COUNT: 5,
   PAGE_VIEW_ID: 'pageViewId',
   PAGE_VIEW_TIMESTAMP: 'pageViewTimestamp',
@@ -274,19 +274,16 @@ function getUserSyncs(syncOptions, _, gdprConsent, usPrivacy, gppConsent) {
     return syncs;
   }
   if (syncOptions.iframeEnabled && seed && clientId) {
-    for (let i = 0; i < CERBERUS.SYNC_COUNT; i++) {
-      syncs.push({
-        type: 'iframe',
-        url: CERBERUS.SYNC_URL.replace('{UUID}', clientId)
-          .replace('{SEED}', seed)
-          .replace('{INDEX}', i)
-          .replace('{GDPR}', gdpr)
-          .replace('{GDPR_CONSENT}', gdprConsentString)
-          .replace('{US_PRIVACY}', usPrivacy || '')
-          .replace('{GPP_STRING}', gppString)
-          .replace('{GPP_SID}', gppApplicableSections)
-      });
-    }
+    syncs.push({
+      type: 'iframe',
+      url: CERBERUS.SYNC_URL.replace('{UUID}', clientId)
+        .replace('{SEED}', seed)
+        .replace('{GDPR}', gdpr)
+        .replace('{GDPR_CONSENT}', gdprConsentString)
+        .replace('{US_PRIVACY}', usPrivacy || '')
+        .replace('{GPP_STRING}', gppString)
+        .replace('{GPP_SID}', gppApplicableSections)
+    })
   }
   return syncs;
 }

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -1885,16 +1885,15 @@ describe('kargo adapter tests', function() {
   describe('getUserSyncs', function() {
     let crb = {};
     const clientId = 'random-client-id-string';
-    const baseUrl = 'https://crb.kargo.com/api/v1/initsyncrnd/random-client-id-string?seed=3205e885-8d37-4139-b47e-f82cff268000&idx=0&gdpr=0&gdpr_consent=&us_privacy=&gpp=&gpp_sid=';
+    const baseUrl = 'https://crb.kargo.com/api/v1/initsyncrnd/random-client-id-string?seed=3205e885-8d37-4139-b47e-f82cff268000&gdpr=0&gdpr_consent=&us_privacy=&gpp=&gpp_sid=';
 
-    function buildSyncUrls(baseUrl = 'https://crb.kargo.com/api/v1/initsyncrnd/random-client-id-string?seed=3205e885-8d37-4139-b47e-f82cff268000&idx=0&gdpr=0&gdpr_consent=&us_privacy=&gpp=&gpp_sid=') {
+    function buildSyncUrls(baseUrl = 'https://crb.kargo.com/api/v1/initsyncrnd/random-client-id-string?seed=3205e885-8d37-4139-b47e-f82cff268000&gdpr=0&gdpr_consent=&us_privacy=&gpp=&gpp_sid=') {
       let syncs = [];
-      for (let i = 0; i < 5; i++) {
-        syncs.push({
-          type: 'iframe',
-          url: baseUrl.replace(/idx=\d+&/, `idx=${i}&`),
-        });
-      }
+
+      syncs.push({
+        type: 'iframe',
+        url: baseUrl
+      });
 
       return syncs;
     }


### PR DESCRIPTION
Cerberus now returns an iframe of syncs when idx is either not provided (ongoing support) or idx=0 (legacy support). 

![Screenshot 2024-07-03 at 2 55 05 PM](https://github.com/KargoGlobal/Prebid.js/assets/12804307/8589fe61-0fb6-41b6-aca0-03e64b0ca528)
