### PR TITLE
SSPF-3301: Kargo Adapter: use gppString for GPP consent (fix Prebid API)

### DIFF
--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -268,7 +268,7 @@ function getUserSyncs(syncOptions, _, gdprConsent, usPrivacy, gppConsent) {
   var gdpr = (gdprConsent && gdprConsent.gdprApplies) ? 1 : 0;
   var gdprConsentString = (gdprConsent && gdprConsent.consentString) ? gdprConsent.consentString : '';
 
-  var gppString = (gppConsent && gppConsent.consentString) ? gppConsent.consentString : '';
+  var gppString = (gppConsent && gppConsent.gppString) ? gppConsent.gppString : '';
   var gppApplicableSections = (gppConsent && gppConsent.applicableSections && Array.isArray(gppConsent.applicableSections)) ? gppConsent.applicableSections.join(',') : '';
 
   // don't sync if opted out via usPrivacy
@@ -410,11 +410,11 @@ function getUserIds(tdidAdapter, usp, gdpr, eids, gpp) {
     userIds.sharedIDEids = eids;
   }
 
-  // GPP
+  // GPP (Prebid provides gppConsent.gppString, not consentString)
   if (gpp) {
     const parsedGPP = {};
-    if (gpp.consentString) {
-      parsedGPP.gppString = gpp.consentString;
+    if (gpp.gppString) {
+      parsedGPP.gppString = gpp.gppString;
     }
     if (gpp.applicableSections) {
       parsedGPP.applicableSections = gpp.applicableSections;

--- a/modules/kargoBidAdapter.js
+++ b/modules/kargoBidAdapter.js
@@ -410,7 +410,7 @@ function getUserIds(tdidAdapter, usp, gdpr, eids, gpp) {
     userIds.sharedIDEids = eids;
   }
 
-  // GPP (Prebid provides gppConsent.gppString, not consentString)
+  // GPP
   if (gpp) {
     const parsedGPP = {};
     if (gpp.gppString) {

--- a/test/spec/modules/kargoBidAdapter_spec.js
+++ b/test/spec/modules/kargoBidAdapter_spec.js
@@ -1253,7 +1253,7 @@ describe('kargo adapter tests', function() {
 
       it('fetches gpp from the bidder request if present', function() {
         bidderRequest.gppConsent = {
-          consentString: 'gppString',
+          gppString: 'gppString',
           applicableSections: [-1]
         };
         const payload = getPayloadFromTestBids([{ ...minimumBidParams }]);
@@ -1266,7 +1266,7 @@ describe('kargo adapter tests', function() {
 
       it('does not send empty gpp values', function() {
         bidderRequest.gppConsent = {
-          consentString: '',
+          gppString: '',
           applicableSections: ''
         };
         const payload = getPayloadFromTestBids([{ ...minimumBidParams }]);
@@ -2045,13 +2045,13 @@ describe('kargo adapter tests', function() {
 
     it('includes gpp information if provided', function() {
       [
-        { applicableSections: [-1], consentString: 'test-consent-string', as: '-1', cs: 'test-consent-string' },
-        { applicableSections: [1, 2, 3], consentString: 'test-consent-string', as: '1,2,3', cs: 'test-consent-string' },
+        { applicableSections: [-1], gppString: 'test-consent-string', as: '-1', cs: 'test-consent-string' },
+        { applicableSections: [1, 2, 3], gppString: 'test-consent-string', as: '1,2,3', cs: 'test-consent-string' },
         { applicableSections: [-1], as: '-1', cs: '' },
-        { applicableSections: false, consentString: 'test-consent-string', as: '', cs: 'test-consent-string' },
-        { applicableSections: null, consentString: 'test-consent-string', as: '', cs: 'test-consent-string' },
-        { applicableSections: {}, consentString: 'test-consent-string', as: '', cs: 'test-consent-string' },
-        { applicableSections: [], consentString: 'test-consent-string', as: '', cs: 'test-consent-string' },
+        { applicableSections: false, gppString: 'test-consent-string', as: '', cs: 'test-consent-string' },
+        { applicableSections: null, gppString: 'test-consent-string', as: '', cs: 'test-consent-string' },
+        { applicableSections: {}, gppString: 'test-consent-string', as: '', cs: 'test-consent-string' },
+        { applicableSections: [], gppString: 'test-consent-string', as: '', cs: 'test-consent-string' },
         { as: '', cs: '' },
       ].forEach(value => expect(getUserSyncs(undefined, undefined, value), `Value - ${value}`)
         .to.deep.equal(buildSyncUrls(baseUrl
@@ -2077,7 +2077,7 @@ describe('kargo adapter tests', function() {
       expect(getUserSyncs(
         { gdprApplies: true, consentString: 'test-gdpr-consent' },
         '1---',
-        { applicableSections: [1, 2, 3], consentString: 'test-gpp-consent' }
+        { applicableSections: [1, 2, 3], gppString: 'test-gpp-consent' }
       )).to.deep.equal(buildSyncUrls(baseUrl
         .replace(/gdpr=\d/, 'gdpr=1')
         .replace(/gdpr_consent=/, 'gdpr_consent=test-gdpr-consent')


### PR DESCRIPTION
## Type of change
- [x] Bugfix
- [x] Updated bidder adapter

## Description of change

The Kargo bid adapter was incorrectly reading `gpp.consentString` but Prebid.js provides the GPP consent string at `bidderRequest.gppConsent.gppString` (per the [GPP integration documentation](https://docs.prebid.org/dev-docs/modules/consentManagementGpp.html#bidder-adapter-gpp-integration)).

This fix updates both `getUserIds()` and `getUserSyncs()` functions to correctly reference `gppString` instead of `consentString`, ensuring the GPP consent string is properly sent to Kraken.

**Changes:**
- `modules/kargoBidAdapter.js` line 271: Fixed `getUserSyncs()` to use `gppConsent.gppString`
- `modules/kargoBidAdapter.js` line 416: Fixed `getUserIds()` to use `gpp.gppString`  
- `test/spec/modules/kargoBidAdapter_spec.js`: Updated all test mocks to use `gppString` (~11 locations)

**Testing:**
- ✅ All 83 existing Kargo adapter tests pass
- ✅ Updated test mocks properly validate `gppString` usage
- ✅ Linting passes with no issues

**Related:**
- JIRA: https://kargo1.atlassian.net/browse/SSPF-3301
- Prebid GPP docs: https://docs.prebid.org/dev-docs/modules/consentManagementGpp.html#bidder-adapter-gpp-integration

## Other information

Medium priority - ext.ortb2 can be referenced in the meantime within Kraken as a workaround (see SSPF-3302).

Contact: SSP Features team (@KargoGlobal/ssp-features)